### PR TITLE
Add configuration for where gulpfile.js is located

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ So as an example, you can make sure a local version of gulp exists using this:
     // runs "gulp build" as part of your gradle build
     build.dependsOn gulp_build
 
+Configuring the Plugin
+----------------------
+
+You can configure the plugin using the "gulp" extension block, like this:
+
+    gulp {
+        // Set the directory where gulpfile.js should be found
+        workDir = file("${project.projectDir}")
+    }
 
 Automatically downloading Node
 ------------------------------

--- a/src/main/groovy/com/moowork/gradle/gulp/GulpExtension.groovy
+++ b/src/main/groovy/com/moowork/gradle/gulp/GulpExtension.groovy
@@ -1,0 +1,15 @@
+package com.moowork.gradle.gulp
+
+import org.gradle.api.Project
+
+class GulpExtension
+{
+    final static String NAME = 'gulp'
+
+    def File workDir
+
+    GulpExtension( final Project project )
+    {
+        this.workDir = project.projectDir
+    }
+}

--- a/src/main/groovy/com/moowork/gradle/gulp/GulpInstallTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/gulp/GulpInstallTask.groovy
@@ -14,6 +14,8 @@ class GulpInstallTask
 
         setArgs( ['install', 'gulp'] )
 
-        getOutputs().dir( 'node_modules/gulp' )
+        this.project.afterEvaluate {
+            getOutputs().dir( new File( this.project.node.nodeModulesDir, 'node_modules/gulp' ) )
+        }
     }
 }

--- a/src/main/groovy/com/moowork/gradle/gulp/GulpInstallTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/gulp/GulpInstallTask.groovy
@@ -15,6 +15,7 @@ class GulpInstallTask
         setArgs( ['install', 'gulp'] )
 
         this.project.afterEvaluate {
+            setWorkingDir( this.project.node.nodeModulesDir )
             getOutputs().dir( new File( this.project.node.nodeModulesDir, 'node_modules/gulp' ) )
         }
     }

--- a/src/main/groovy/com/moowork/gradle/gulp/GulpPlugin.groovy
+++ b/src/main/groovy/com/moowork/gradle/gulp/GulpPlugin.groovy
@@ -15,6 +15,8 @@ class GulpPlugin
     {
         project.plugins.apply( NodePlugin.class )
 
+        project.extensions.create( GulpExtension.NAME, GulpExtension, project )
+
         project.extensions.extraProperties.set( 'GulpTask', GulpTask.class )
         project.tasks.create( GULP_INSTALL_NAME, GulpInstallTask.class )
 

--- a/src/main/groovy/com/moowork/gradle/gulp/GulpTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/gulp/GulpTask.groovy
@@ -16,13 +16,14 @@ class GulpTask
     @Override
     void exec()
     {
-        def localGulp = this.project.file( GULP_SCRIPT )
+        def localGulp = this.project.file( new File( this.project.node.nodeModulesDir, GULP_SCRIPT ) )
         if ( !localGulp.isFile() )
         {
             throw new GradleException(
                 "gulp not installed in node_modules, please first run 'gradle ${GulpPlugin.GULP_INSTALL_NAME}'" )
         }
 
+        setWorkingDir( this.project.gulp.workDir )
         setScript( localGulp )
         super.exec()
     }


### PR DESCRIPTION
This depends on gradle-node-plugin PR https://github.com/srs/gradle-node-plugin/pull/52

Add new 'gulp' extension with option workDir. By default workDir = projectDir.
