### PR TITLE
Add support to buffer output and disable colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ So as an example, you can make sure a local version of gulp exists using this:
     // runs "gulp build" as part of your gradle build
     build.dependsOn gulp_build
 
+Configuring the Plugin
+----------------------
+
+You can configure the plugin using the "gulp" extension block, like this:
+
+    gulp {
+        // Set the directory where gulpfile.js should be found
+        workDir = file("${project.projectDir}")
+    }
 
 Automatically downloading Node
 ------------------------------

--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ You can configure the plugin using the "gulp" extension block, like this:
     gulp {
         // Set the directory where gulpfile.js should be found
         workDir = file("${project.projectDir}")
+
+        // Whether colors should output on the terminal
+        colors = true
+
+        // Whether output from Gulp should be buffered - useful when running tasks in parallel
+        bufferOutput = false
     }
 
 Automatically downloading Node

--- a/src/main/groovy/com/moowork/gradle/gulp/GulpExtension.groovy
+++ b/src/main/groovy/com/moowork/gradle/gulp/GulpExtension.groovy
@@ -6,7 +6,11 @@ class GulpExtension
 {
     final static String NAME = 'gulp'
 
-    def File workDir
+    File workDir
+
+    Boolean colors = true
+
+    Boolean bufferOutput = false
 
     GulpExtension( final Project project )
     {

--- a/src/main/groovy/com/moowork/gradle/gulp/GulpExtension.groovy
+++ b/src/main/groovy/com/moowork/gradle/gulp/GulpExtension.groovy
@@ -1,0 +1,15 @@
+package com.moowork.gradle.gulp
+
+import org.gradle.api.Project
+
+class GulpExtension
+{
+    final static String NAME = 'gulp'
+
+    def File workDir
+
+    GulpExtension( final Project project )
+    {
+        this.workDir = project.projectDir
+    }
+}

--- a/src/main/groovy/com/moowork/gradle/gulp/GulpInstallTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/gulp/GulpInstallTask.groovy
@@ -14,6 +14,8 @@ class GulpInstallTask
 
         setArgs( ['install', 'gulp'] )
 
-        getOutputs().dir( 'node_modules/gulp' )
+        this.project.afterEvaluate {
+            getOutputs().dir( new File( this.project.node.nodeModulesDir, 'node_modules/gulp' ) )
+        }
     }
 }

--- a/src/main/groovy/com/moowork/gradle/gulp/GulpInstallTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/gulp/GulpInstallTask.groovy
@@ -15,6 +15,7 @@ class GulpInstallTask
         setArgs( ['install', 'gulp'] )
 
         this.project.afterEvaluate {
+            setWorkingDir( this.project.node.nodeModulesDir )
             getOutputs().dir( new File( this.project.node.nodeModulesDir, 'node_modules/gulp' ) )
         }
     }

--- a/src/main/groovy/com/moowork/gradle/gulp/GulpPlugin.groovy
+++ b/src/main/groovy/com/moowork/gradle/gulp/GulpPlugin.groovy
@@ -15,6 +15,8 @@ class GulpPlugin
     {
         project.plugins.apply( NodePlugin.class )
 
+        project.extensions.create( GulpExtension.NAME, GulpExtension, project )
+
         project.extensions.extraProperties.set( 'GulpTask', GulpTask.class )
         project.tasks.create( GULP_INSTALL_NAME, GulpInstallTask.class )
 

--- a/src/main/groovy/com/moowork/gradle/gulp/GulpTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/gulp/GulpTask.groovy
@@ -23,8 +23,36 @@ class GulpTask
                 "gulp not installed in node_modules, please first run 'gradle ${GulpPlugin.GULP_INSTALL_NAME}'" )
         }
 
+        // If colors are disabled, add --no-color to args
+        if ( !this.project.gulp.colors ) {
+            def tempArgs = []
+            tempArgs.addAll( args as List )
+            tempArgs.add( '--no-color' )
+            setArgs( tempArgs )
+        }
+
+        // If output should be buffered (useful when running in parallel)
+        // set standardOutput of ExecRunner to a buffer
+        def bufferedOutput
+        if ( this.project.gulp.bufferOutput ) {
+            bufferedOutput = new ByteArrayOutputStream()
+            setExecOverrides({
+                it.standardOutput = bufferedOutput
+            })
+        }
+
         setWorkingDir( this.project.gulp.workDir )
         setScript( localGulp )
-        super.exec()
+
+        // If the exec fails, make sure to still print output
+        try {
+            super.exec()
+        } finally {
+            // If we were buffering output, print it
+            if ( this.project.gulp.bufferOutput ) {
+                println "Output from ${this.project.gulp.workDir}/gulpfile.js"
+                println bufferedOutput.toString()
+            }
+        }
     }
 }

--- a/src/main/groovy/com/moowork/gradle/gulp/GulpTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/gulp/GulpTask.groovy
@@ -16,13 +16,14 @@ class GulpTask
     @Override
     void exec()
     {
-        def localGulp = this.project.file( GULP_SCRIPT )
+        def localGulp = this.project.file( new File( this.project.node.nodeModulesDir, GULP_SCRIPT ) )
         if ( !localGulp.isFile() )
         {
             throw new GradleException(
                 "gulp not installed in node_modules, please first run 'gradle ${GulpPlugin.GULP_INSTALL_NAME}'" )
         }
 
+        setWorkingDir( this.project.gulp.workDir )
         setScript( localGulp )
         super.exec()
     }


### PR DESCRIPTION
Depends on #4.

Will buffer output from the underlying gulp process. This is useful when building multiple gulp projects with --parallel so you don't need to try to figure out the interleaved output.
