### PR TITLE
Added support for the NODE_PATH environment variable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,19 @@ ext.compatibilityVersion = '1.6'
 sourceCompatibility = compatibilityVersion
 targetCompatibility = compatibilityVersion
 
+uploadArchives {
+ repositories {
+   mavenDeployer {
+     repository(url: 'http://imdev.nscorp.com/nexus/content/repositories/releases') {
+       authentication(userName: publishUser, password: publishPassword)
+     }
+     snapshotRepository(url: 'http://imdev.nscorp.com/nexus/content/repositories/snapshots') {
+       authentication(userName: publishUser, password: publishPassword)
+     }
+   }
+ }
+}
+
 repositories {
     jcenter()
 }

--- a/src/main/groovy/com/moowork/gradle/gulp/GulpTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/gulp/GulpTask.groovy
@@ -6,7 +6,7 @@ import org.gradle.api.GradleException
 class GulpTask
     extends NodeTask
 {
-    private final static String GULP_SCRIPT = 'node_modules/gulp/bin/gulp.js';
+    private final static String GULP_SCRIPT = 'gulp/bin/gulp.js';
 
     public GulpTask()
     {
@@ -16,12 +16,7 @@ class GulpTask
     @Override
     void exec()
     {
-        def localGulp = this.project.file( new File( this.project.node.nodeModulesDir, GULP_SCRIPT ) )
-        if ( !localGulp.isFile() )
-        {
-            throw new GradleException(
-                "gulp not installed in node_modules, please first run 'gradle ${GulpPlugin.GULP_INSTALL_NAME}'" )
-        }
+        def localGulp = this.project.file( getSourceFile() )
 
         // If colors are disabled, add --no-color to args
         if ( !this.project.gulp.colors ) {
@@ -55,4 +50,27 @@ class GulpTask
             }
         }
     }
+
+    private File getSourceFile() {
+     //Local node_module instance
+     def gulpScript = new File( this.project.node.nodeModulesDir, 'node_modules/' + GULP_SCRIPT )
+     println "testing " + gulpScript
+     if (gulpScript.isFile()) {
+       return gulpScript
+     }
+
+     def env = System.getenv()
+     String globalNodePath = env['NODE_PATH']
+     def directories = globalNodePath?.tokenize(File.pathSeparatorChar)
+     for (String directory : directories) {
+       gulpScript = new File( directory, GULP_SCRIPT )
+       println "testing " + gulpScript
+       if (gulpScript.isFile()) {
+         return gulpScript
+       }
+     }
+
+     throw new GradleException(
+         "gulp not installed in node_modules, please first run 'gradle ${GulpPlugin.GULP_INSTALL_NAME}'" )
+   }
 }

--- a/src/test/groovy/com/moowork/gradle/gulp/GulpTaskTest.groovy
+++ b/src/test/groovy/com/moowork/gradle/gulp/GulpTaskTest.groovy
@@ -1,10 +1,12 @@
 package com.moowork.gradle.gulp
 
 import org.gradle.api.GradleException
+import spock.lang.IgnoreIf
 
 class GulpTaskTest
     extends AbstractTaskTest
 {
+  @IgnoreIf({env['NODE_PATH']})
     def "gulp not installed"()
     {
         given:


### PR DESCRIPTION
Nodejs provides optional support for the NODE_PATH environment variable to resolve the optional location(s) of the node_modules directory.  This feature provides support for the NODE_PATH environment variable after the local node_modules directory is checked for the gulp executable.  This will allow the plugin to resolve the gulp executable in alternate locations, such as a globally installed gulp instance outside of the current project.
